### PR TITLE
Increase section title font sizes for better visual hierarchy

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
 
                 <div class="market-context-panel">
                     <div class="section-header" style="padding: 0 0 16px 0;">
-                        <h3 class="section-title" style="font-size: 16px;"><span class="has-tooltip" data-tooltip="Broader Nashville MSA real estate market indicators providing context for strategy performance. Includes all property types and price ranges.">Market Context</span></h3>
+                        <h3 class="section-title" style="font-size: 22px;"><span class="has-tooltip" data-tooltip="Broader Nashville MSA real estate market indicators providing context for strategy performance. Includes all property types and price ranges.">Market Context</span></h3>
                         <div class="section-meta"><span class="has-tooltip" data-tooltip="Market-wide statistics for benchmarking strategy performance. Helps identify if strategy outperformance is due to selection criteria or overall market conditions.">Nashville MSA</span></div>
                     </div>
                     <div class="context-list">

--- a/styles.css
+++ b/styles.css
@@ -229,7 +229,7 @@
         }
 
         .card-title {
-            font-size: 16px;
+            font-size: 22px;
             font-weight: 600;
             color: #111827;
         }
@@ -272,7 +272,7 @@
         }
 
         .table-title {
-            font-size: 16px;
+            font-size: 22px;
             font-weight: 600;
             color: #111827;
         }
@@ -378,7 +378,7 @@
         }
 
         .kpi-title {
-            font-size: 18px;
+            font-size: 22px;
             font-weight: 600;
             color: #111827;
             margin-bottom: 4px;
@@ -458,7 +458,7 @@
         }
 
         .section-title {
-            font-size: 18px;
+            font-size: 22px;
             font-weight: 600;
             color: #111827;
         }
@@ -862,7 +862,7 @@
         }
 
         .chart-title {
-            font-size: 16px;
+            font-size: 22px;
             font-weight: 600;
             color: #111827;
             margin-bottom: 4px;


### PR DESCRIPTION
Updated all major section titles from varying sizes (16px-18px) to consistent 22px across Market and Pipeline tabs for improved readability and visual prominence.

🤖 Generated with [Claude Code](https://claude.ai/code)